### PR TITLE
传图增加ack, 优化传输速度

### DIFF
--- a/EPD/EPD_service.c
+++ b/EPD/EPD_service.c
@@ -101,6 +101,61 @@ static void epd_send_mtu(ble_epd_t* p_epd) {
     ble_epd_string_send(p_epd, (uint8_t*)buf, strlen(buf));
 }
 
+// CRC16-CCITT calculation (polynomial 0x8408, init 0xFFFF)
+static uint16_t crc16_compute(const uint8_t* data, uint16_t len) {
+    uint16_t crc = 0xFFFF;
+    for (uint16_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (uint8_t j = 0; j < 8; j++) {
+            crc = (crc & 1) ? (crc >> 1) ^ 0x8408 : crc >> 1;
+        }
+    }
+    return crc;
+}
+
+// Send block ACK/NACK response
+static void send_block_response(ble_epd_t* p_epd, uint16_t block_id, uint8_t status) {
+    uint8_t response[4] = {
+        EPD_RSP_BLOCK_ACK,
+        block_id & 0xFF,
+        block_id >> 8,
+        status
+    };
+    ble_epd_string_send(p_epd, response, 4);
+}
+
+// Send transfer status response
+// Only sends used bitmap bytes to stay within MTU limits
+static void send_status_response(ble_epd_t* p_epd) {
+    // Calculate required bitmap bytes based on total blocks
+    uint16_t bitmap_bytes = (p_epd->transfer_ctx.total_blocks + 7) / 8;
+    if (bitmap_bytes > EPD_BLOCK_BITMAP_SIZE) {
+        bitmap_bytes = EPD_BLOCK_BITMAP_SIZE;
+    }
+
+    uint16_t response_len = 7 + bitmap_bytes;
+
+    // Ensure response fits in MTU (with safety check for min MTU)
+    if (p_epd->max_data_len < 7) {
+        return;  // MTU too small, cannot send status
+    }
+    if (response_len > p_epd->max_data_len) {
+        bitmap_bytes = p_epd->max_data_len - 7;
+        response_len = p_epd->max_data_len;
+    }
+
+    uint8_t response[7 + EPD_BLOCK_BITMAP_SIZE];
+    response[0] = EPD_RSP_STATUS;
+    response[1] = p_epd->transfer_ctx.total_blocks & 0xFF;
+    response[2] = p_epd->transfer_ctx.total_blocks >> 8;
+    response[3] = p_epd->transfer_ctx.received_blocks & 0xFF;
+    response[4] = p_epd->transfer_ctx.received_blocks >> 8;
+    response[5] = p_epd->transfer_ctx.session_id;
+    response[6] = p_epd->transfer_ctx.transfer_active ? 1 : 0;
+    memcpy(&response[7], p_epd->transfer_ctx.block_bitmap, bitmap_bytes);
+    ble_epd_string_send(p_epd, response, response_len);
+}
+
 static void epd_service_on_write(ble_epd_t* p_epd, uint8_t* p_data, uint16_t length) {
     NRF_LOG_DEBUG("[EPD]: on_write LEN=%d\n", length);
     NRF_LOG_HEXDUMP_DEBUG(p_data, length);
@@ -182,6 +237,77 @@ static void epd_service_on_write(ble_epd_t* p_epd, uint8_t* p_data, uint16_t len
         case EPD_CMD_WRITE_IMAGE:  // MSB=0000: ram begin, LSB=1111: black
             if (length < 3) return;
             p_epd->epd->drv->write_ram(p_epd->epd, p_data[1], &p_data[2], length - 2);
+            break;
+
+        case EPD_CMD_WRITE_BLOCK: {
+            // Data format: [cmd(1)][block_id(2)][total(2)][cfg(1)][payload(N)][crc16(2)]
+            if (length < 8) return;  // Minimum length check
+
+            // Parse block_id first (needed for NACK response)
+            uint16_t block_id = p_data[1] | (p_data[2] << 8);
+
+            // Validate EPD is initialized
+            if (p_epd->epd == NULL || p_epd->epd->drv == NULL) {
+                send_block_response(p_epd, block_id, 0x03);  // NACK - EPD not initialized
+                break;
+            }
+
+            uint16_t total = p_data[3] | (p_data[4] << 8);
+            uint8_t cfg = p_data[5];  // Layer + first block flag
+            uint16_t payload_len = length - 8;
+            uint8_t* payload = &p_data[6];
+            uint16_t recv_crc = p_data[length - 2] | (p_data[length - 1] << 8);
+
+            // Validate block_id and total are within limits
+            if (block_id >= EPD_MAX_BLOCKS || total > EPD_MAX_BLOCKS) {
+                send_block_response(p_epd, block_id, 0x02);  // NACK - invalid block ID
+                break;
+            }
+
+            // Calculate CRC (only verify payload)
+            uint16_t calc_crc = crc16_compute(payload, payload_len);
+
+            if (calc_crc == recv_crc) {
+                // Initialize transfer context on first block or if not active
+                if (block_id == 0 || !p_epd->transfer_ctx.transfer_active) {
+                    p_epd->transfer_ctx.total_blocks = total;
+                    p_epd->transfer_ctx.received_blocks = 0;
+                    memset(p_epd->transfer_ctx.block_bitmap, 0, EPD_BLOCK_BITMAP_SIZE);
+                    p_epd->transfer_ctx.transfer_active = true;
+                }
+
+                // Check if block already received (avoid duplicate)
+                uint16_t byte_idx = block_id / 8;
+                uint8_t bit_idx = block_id % 8;
+                if (byte_idx < EPD_BLOCK_BITMAP_SIZE &&
+                    !(p_epd->transfer_ctx.block_bitmap[byte_idx] & (1 << bit_idx))) {
+                    // New block: write to EPD RAM using cfg from APP
+                    p_epd->epd->drv->write_ram(p_epd->epd, cfg, payload, payload_len);
+
+                    // Mark block as received
+                    p_epd->transfer_ctx.block_bitmap[byte_idx] |= (1 << bit_idx);
+                    p_epd->transfer_ctx.received_blocks++;
+                }
+
+                send_block_response(p_epd, block_id, 0x00);  // ACK
+            } else {
+                send_block_response(p_epd, block_id, 0x01);  // NACK - CRC error
+            }
+            break;
+        }
+
+        case EPD_CMD_QUERY_STATUS:
+            send_status_response(p_epd);
+            break;
+
+        case EPD_CMD_RESET_TRANSFER:
+            if (length >= 2) {
+                p_epd->transfer_ctx.session_id = p_data[1];
+            }
+            p_epd->transfer_ctx.total_blocks = 0;
+            p_epd->transfer_ctx.received_blocks = 0;
+            memset(p_epd->transfer_ctx.block_bitmap, 0, EPD_BLOCK_BITMAP_SIZE);
+            p_epd->transfer_ctx.transfer_active = false;
             break;
 
         case EPD_CMD_SET_CONFIG:
@@ -327,6 +453,9 @@ uint32_t ble_epd_init(ble_epd_t* p_epd) {
     p_epd->max_data_len = BLE_EPD_MAX_DATA_LEN;
     p_epd->conn_handle = BLE_CONN_HANDLE_INVALID;
     p_epd->is_notification_enabled = false;
+
+    // Initialize transfer context
+    memset(&p_epd->transfer_ctx, 0, sizeof(image_transfer_ctx_t));
 
     epd_config_init(&p_epd->config);
     epd_config_read(&p_epd->config);

--- a/EPD/EPD_service.h
+++ b/EPD/EPD_service.h
@@ -74,11 +74,32 @@ enum EPD_CMDS {
 
     EPD_CMD_WRITE_IMAGE = 0x30, /** < write image data to EPD ram */
 
+    EPD_CMD_WRITE_BLOCK    = 0x31,   /**< write block with CRC verification */
+    EPD_CMD_QUERY_STATUS   = 0x32,   /**< query transfer status */
+    EPD_CMD_RESET_TRANSFER = 0x33,   /**< reset transfer state */
+
     EPD_CMD_SET_CONFIG = 0x90, /**< set full EPD config */
     EPD_CMD_SYS_RESET = 0x91,  /**< MCU reset */
     EPD_CMD_SYS_SLEEP = 0x92,  /**< MCU enter sleep mode */
     EPD_CMD_CFG_ERASE = 0x99,  /**< Erase config and reset */
 };
+
+// Response types for CRC transfer
+#define EPD_RSP_BLOCK_ACK       0xA0  // Block ACK/NACK response
+#define EPD_RSP_STATUS          0xA1  // Status response
+
+// Transfer configuration
+#define EPD_MAX_BLOCKS          512   // Maximum blocks (96KB / 192B)
+#define EPD_BLOCK_BITMAP_SIZE   64    // Bitmap size (512 bits)
+
+/**@brief Image transfer context for resume capability */
+typedef struct {
+    uint8_t  session_id;                          /**< Session ID for transfer identification */
+    uint16_t total_blocks;                        /**< Total number of blocks */
+    uint16_t received_blocks;                     /**< Number of received blocks */
+    uint8_t  block_bitmap[EPD_BLOCK_BITMAP_SIZE]; /**< Bitmap of received blocks */
+    bool     transfer_active;                     /**< Whether transfer is active */
+} image_transfer_ctx_t;
 
 /**@brief EPD Service structure.
  *
@@ -97,6 +118,7 @@ typedef struct {
                                      characteristic.*/
     epd_model_t* epd;             /**< current EPD model */
     epd_config_t config;          /**< EPD config */
+    image_transfer_ctx_t transfer_ctx; /**< Image transfer context for CRC and resume */
 } ble_epd_t;
 
 typedef struct {

--- a/docs/BLE_CRC_Transfer_Design.md
+++ b/docs/BLE_CRC_Transfer_Design.md
@@ -1,0 +1,184 @@
+# BLE图像传输CRC校验与断点续传设计方案
+
+> **版本**: v1.0  
+> **日期**: 2026-02-01  
+> **状态**: 已实现
+
+## 1. 概述
+
+本方案为BLE图像传输实现数据完整性保护，解决以下问题：
+- **无校验机制**：数据包直接写入EPD RAM，无法检测丢包或损坏
+- **不可恢复**：一旦数据丢失，无法重传，导致显示错乱
+- **断连后丢失**：重连后需要从头开始传输
+
+---
+
+## 2. 协议设计
+
+### 2.1 新增命令
+
+| 命令 | ID | 方向 | 说明 |
+|------|-----|------|------|
+| WRITE_BLOCK | 0x31 | APP→MCU | 带CRC的数据块写入 |
+| QUERY_STATUS | 0x32 | APP→MCU | 查询传输状态 |
+| RESET_TRANSFER | 0x33 | APP→MCU | 重置传输上下文 |
+
+### 2.2 响应类型
+
+| 响应 | ID | 方向 | 说明 |
+|------|-----|------|------|
+| BLOCK_ACK | 0xA0 | MCU→APP | 块ACK/NACK响应 |
+| STATUS | 0xA1 | MCU→APP | 传输状态响应 |
+
+---
+
+## 3. 数据包格式
+
+### 3.1 WRITE_BLOCK (0x31)
+
+```
+┌─────────┬──────────┬───────────┬─────────┬────────────┬──────────┐
+│ CMD     │ Block ID │ Total Blk │ CFG     │ Payload    │ CRC16    │
+│ (1byte) │ (2bytes) │ (2bytes)  │ (1byte) │ (N bytes)  │ (2bytes) │
+└─────────┴──────────┴───────────┴─────────┴────────────┴──────────┘
+```
+
+**CFG字节格式**:
+- bit[3:0]: 图层 (`0x0F`=黑白层, `0x00`=颜色层)
+- bit[7:4]: 首块标志 (`0x00`=首块需发送RAM命令, `0xF0`=续块)
+
+### 3.2 BLOCK_ACK响应 (0xA0)
+
+```
+┌─────────┬──────────┬─────────┐
+│ RSP     │ Block ID │ Status  │
+│ (1byte) │ (2bytes) │ (1byte) │
+└─────────┴──────────┴─────────┘
+```
+
+**Status值**:
+| 值 | 含义 |
+|----|------|
+| 0x00 | ACK - 成功 |
+| 0x01 | NACK - CRC错误 |
+| 0x02 | NACK - block_id无效 |
+| 0x03 | NACK - EPD未初始化 |
+
+### 3.3 STATUS响应 (0xA1)
+
+```
+┌─────────┬───────┬──────────┬─────────┬────────┬────────────┐
+│ RSP     │ Total │ Received │ Session │ Active │ Bitmap     │
+│ (1byte) │ (2B)  │ (2bytes) │ (1byte) │ (1byte)│ (N bytes)  │
+└─────────┴───────┴──────────┴─────────┴────────┴────────────┘
+```
+
+Bitmap长度根据total_blocks动态计算，最大64字节。
+
+---
+
+## 4. CRC16算法
+
+使用**CRC16-CCITT**算法：
+- 多项式: 0x8408 (反转形式)
+- 初始值: 0xFFFF
+- 只校验payload部分
+
+```c
+// MCU端实现
+static uint16_t crc16_compute(const uint8_t* data, uint16_t len) {
+    uint16_t crc = 0xFFFF;
+    for (uint16_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (uint8_t j = 0; j < 8; j++) {
+            crc = (crc & 1) ? (crc >> 1) ^ 0x8408 : crc >> 1;
+        }
+    }
+    return crc;
+}
+```
+
+---
+
+## 5. 传输流程
+
+### 5.1 首次传输
+
+```
+APP                                MCU
+ │                                  │
+ ├──RESET_TRANSFER(session_id)────>│  重置状态
+ │                                  │
+ ├──WRITE_BLOCK(0, total, data)───>│  发送首块
+ ├──WRITE_BLOCK(1, total, data)───>│
+ │  ... (批量发送，不等ACK)         │
+ ├──WRITE_BLOCK(N, total, data)───>│  最后一块(withResponse)
+ │                                  │
+ ├──QUERY_STATUS─────────────────->│
+ │<─STATUS(bitmap)─────────────────│  获取缺失块信息
+ │                                  │
+ │  [若有缺失块，重传]              │
+```
+
+### 5.2 断点续传
+
+```
+APP                                MCU
+ │                                  │
+ ├──QUERY_STATUS─────────────────->│  查询已接收状态
+ │<─STATUS(bitmap)─────────────────│
+ │                                  │
+ │  [解析bitmap，只发送缺失块]      │
+ ├──WRITE_BLOCK(missing_id, ...)──>│
+```
+
+---
+
+## 6. 资源占用
+
+| 资源 | 占用 | 说明 |
+|------|------|------|
+| MCU RAM | +72字节 | `image_transfer_ctx_t`结构体 |
+| MCU Flash | ~800字节 | CRC函数和命令处理 |
+| 传输开销 | +4.2% | 每块增加8字节头尾 |
+
+---
+
+## 7. 配置参数
+
+### MCU端 (EPD_service.h)
+
+```c
+#define EPD_MAX_BLOCKS        512   // 最大块数 (96KB / 192B)
+#define EPD_BLOCK_BITMAP_SIZE 64    // 位图大小 (512 bits)
+```
+
+### APP端 (ble_transfer.js)
+
+```javascript
+MAX_RETRIES: 3,        // 最大重试轮次
+BATCH_SIZE: 20,        // 每批块数
+BATCH_DELAY_MS: 200,   // 批次间延时
+```
+
+---
+
+## 8. 向后兼容
+
+- 保留原有 `EPD_CMD_WRITE_IMAGE (0x30)` 命令
+- APP根据固件版本自动选择传输模式：
+  - 版本 ≥ 0x19: 使用CRC传输
+  - 版本 < 0x19: 使用传统传输
+
+---
+
+## 9. 修改文件清单
+
+### MCU端
+- `EPD/EPD_service.h` - 新增命令、结构体定义
+- `EPD/EPD_service.c` - 实现CRC计算、命令处理
+
+### APP端
+- `html/js/ble_transfer.js` - 新建CRC传输模块
+- `html/js/main.js` - 集成新模块
+- `html/index.html` - 添加脚本引用

--- a/html/index.html
+++ b/html/index.html
@@ -235,7 +235,8 @@
 	<script type="text/javascript" src="js/dithering.js?v=20251109"></script>
 	<script type="text/javascript" src="js/paint.js?v=20251109"></script>
 	<script type="text/javascript" src="js/crop.js?v=20251109"></script>
-	<script type="text/javascript" src="js/main.js?v=20251109"></script>
+	<script type="text/javascript" src="js/ble_transfer.js?v=20260201"></script>
+	<script type="text/javascript" src="js/main.js?v=20260201"></script>
 </body>
 
 </html>

--- a/html/js/ble_transfer.js
+++ b/html/js/ble_transfer.js
@@ -1,0 +1,312 @@
+/**
+ * BLE Transfer Module with CRC Verification and Resume Capability
+ * 
+ * Features:
+ * - CRC16-CCITT verification for data integrity
+ * - Batch confirmation mode (no per-block ACK wait)
+ * - Resume capability via bitmap tracking
+ * - Multi-layer support (black/white and color layers)
+ */
+
+const BleTransfer = {
+  // Configuration
+  MAX_RETRIES: 3,           // Maximum retry rounds
+  BATCH_SIZE: 20,           // Blocks per batch before status check
+  BATCH_DELAY_MS: 200,      // Delay after batch for MCU processing
+
+  // Commands
+  CMD_WRITE_BLOCK: 0x31,
+  CMD_QUERY_STATUS: 0x32,
+  CMD_RESET_TRANSFER: 0x33,
+
+  // Response types
+  RSP_BLOCK_ACK: 0xA0,
+  RSP_STATUS: 0xA1,
+
+  // Current state
+  currentLayer: 0x0F,       // Current layer: 0x0F=black/white, 0x00=color
+  pendingStatus: null,      // Pending status response
+  statusResolver: null,     // Promise resolver for status
+  statusRequestId: 0,       // Request ID to prevent race conditions
+  firstBlockSent: false,    // Track if first block of current layer was sent
+
+  /**
+   * CRC16-CCITT calculation (polynomial 0x8408, init 0xFFFF)
+   * @param {Uint8Array} data - Data to calculate CRC for
+   * @returns {number} 16-bit CRC value
+   */
+  crc16(data) {
+    let crc = 0xFFFF;
+    for (let i = 0; i < data.length; i++) {
+      crc ^= data[i];
+      for (let j = 0; j < 8; j++) {
+        crc = (crc & 1) ? (crc >>> 1) ^ 0x8408 : crc >>> 1;
+      }
+    }
+    return crc & 0xFFFF;
+  },
+
+  /**
+   * Handle notification from MCU
+   * @param {DataView} value - Received notification data
+   */
+  handleNotification(value) {
+    const data = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+
+    if (data.length >= 1) {
+      if (data[0] === this.RSP_STATUS && this.statusResolver) {
+        // Minimum STATUS response is 7 bytes (header + metadata, no bitmap)
+        if (data.length < 7) {
+          console.warn('STATUS response too short:', data.length);
+          return;
+        }
+        // Parse status response
+        // Format: [0xA1, total_L, total_H, received_L, received_H, session, active, bitmap...]
+        const status = {
+          total: data[1] | (data[2] << 8),
+          received: data[3] | (data[4] << 8),
+          sessionId: data[5],
+          active: data[6] === 1,
+          bitmap: data.slice(7)
+        };
+        const resolver = this.statusResolver;
+        this.statusResolver = null;  // Clear before calling to prevent race
+        resolver(status);
+      }
+      // ACK/NACK responses are not waited for in batch mode
+    }
+  },
+
+  /**
+   * Send a single block (fast mode, no ACK wait)
+   * @param {number} blockId - Block ID (0-indexed)
+   * @param {number} totalBlocks - Total number of blocks
+   * @param {Uint8Array} payload - Block payload data
+   * @param {boolean} withResponse - Whether to wait for BLE response
+   */
+  async sendBlockFast(blockId, totalBlocks, payload, withResponse = false) {
+    const crc = this.crc16(payload);
+    // cfg = (first block flag) | (layer)
+    // First block of layer needs RAM command (0x00), continuation uses 0xF0
+    const isFirstBlock = !this.firstBlockSent;
+    const cfg = (isFirstBlock ? 0x00 : 0xF0) | (this.currentLayer & 0x0F);
+
+    if (isFirstBlock) {
+      this.firstBlockSent = true;
+    }
+
+    // Packet format: [cmd][block_id:2][total:2][cfg:1][payload][crc:2]
+    const packet = new Uint8Array(8 + payload.length);
+    packet[0] = this.CMD_WRITE_BLOCK;
+    packet[1] = blockId & 0xFF;
+    packet[2] = blockId >> 8;
+    packet[3] = totalBlocks & 0xFF;
+    packet[4] = totalBlocks >> 8;
+    packet[5] = cfg;
+    packet.set(payload, 6);
+    packet[6 + payload.length] = crc & 0xFF;
+    packet[7 + payload.length] = crc >> 8;
+
+    try {
+      if (withResponse) {
+        await epdCharacteristic.writeValueWithResponse(packet);
+      } else {
+        await epdCharacteristic.writeValueWithoutResponse(packet);
+      }
+    } catch (e) {
+      console.error('Block send failed:', e);
+      throw e;
+    }
+  },
+
+  /**
+   * Reset transfer state on MCU
+   * @param {number} sessionId - Optional session ID
+   */
+  async resetTransfer(sessionId = 0) {
+    this.firstBlockSent = false;  // Reset first block tracking
+    const packet = new Uint8Array([this.CMD_RESET_TRANSFER, sessionId]);
+    await epdCharacteristic.writeValueWithResponse(packet);
+  },
+
+  /**
+   * Query transfer status from MCU
+   * @returns {Promise<object>} Status object with total, received, bitmap
+   */
+  async queryStatus() {
+    const requestId = ++this.statusRequestId;
+    let timeoutId = null;
+
+    return new Promise((resolve, reject) => {
+      this.statusResolver = (status) => {
+        if (timeoutId) clearTimeout(timeoutId);
+        resolve(status);
+      };
+
+      const packet = new Uint8Array([this.CMD_QUERY_STATUS]);
+      epdCharacteristic.writeValueWithResponse(packet).catch((e) => {
+        if (timeoutId) clearTimeout(timeoutId);
+        if (this.statusResolver) {
+          this.statusResolver = null;
+          reject(e);
+        }
+      });
+
+      // Timeout after 3 seconds
+      timeoutId = setTimeout(() => {
+        // Only reject if this is still the current request
+        if (this.statusResolver && this.statusRequestId === requestId) {
+          this.statusResolver = null;
+          reject(new Error('Status query timeout'));
+        }
+      }, 3000);
+    });
+  },
+
+  /**
+   * Get list of missing blocks from status bitmap
+   * @param {object} status - Status object from queryStatus
+   * @param {number} totalBlocks - Expected total blocks
+   * @returns {number[]} Array of missing block IDs
+   */
+  getMissingBlocks(status, totalBlocks) {
+    const missing = [];
+    for (let i = 0; i < totalBlocks; i++) {
+      const byteIdx = Math.floor(i / 8);
+      const bitIdx = i % 8;
+      if (byteIdx < status.bitmap.length) {
+        if (!(status.bitmap[byteIdx] & (1 << bitIdx))) {
+          missing.push(i);
+        }
+      } else {
+        missing.push(i);
+      }
+    }
+    return missing;
+  },
+
+  /**
+   * Send image with CRC verification and resume capability
+   * @param {Uint8Array} data - Image data to send
+   * @param {string} step - 'bw' for black/white, 'red' for color layer
+   * @param {function} onProgress - Progress callback (blocksSent, totalBlocks)
+   * @returns {Promise<boolean>} True if successful
+   */
+  async sendImageWithResume(data, step = 'bw', onProgress = null) {
+    let mtu = parseInt(document.getElementById('mtusize').value);
+    if (isNaN(mtu) || mtu < 20) {
+      console.warn('Invalid MTU value, using default 20');
+      mtu = 20;
+    }
+    const chunkSize = Math.max(mtu - 8, 20); // Account for header/CRC overhead
+    const totalBlocks = Math.ceil(data.length / chunkSize);
+
+    // Statistics tracking
+    const stats = {
+      totalBlocks: totalBlocks,
+      sentBlocks: 0,
+      retries: 0,
+      startTime: Date.now()
+    };
+
+    // Set current layer based on step
+    this.currentLayer = (step === 'bw') ? 0x0F : 0x00;
+
+    // Reset transfer state (also resets firstBlockSent)
+    await this.resetTransfer(Date.now() & 0xFF);
+
+    for (let retryRound = 0; retryRound < this.MAX_RETRIES; retryRound++) {
+      let missingBlocks;
+
+      // Optimization: Skip status query on first round (bitmap is empty after reset)
+      if (retryRound === 0) {
+        // First round: send all blocks
+        missingBlocks = Array.from({ length: totalBlocks }, (_, i) => i);
+      } else {
+        // Retry rounds: query status to find missing blocks
+        let status;
+        try {
+          status = await this.queryStatus();
+        } catch (e) {
+          console.warn('Status query failed, assuming all missing:', e);
+          status = { total: 0, received: 0, bitmap: new Uint8Array(0) };
+        }
+
+        missingBlocks = this.getMissingBlocks(status, totalBlocks);
+
+        if (missingBlocks.length === 0) {
+          // Transfer complete
+          const elapsed = ((Date.now() - stats.startTime) / 1000).toFixed(1);
+          console.log(`Transfer complete: ${stats.totalBlocks} blocks, ${stats.sentBlocks} sent, ${stats.retries} retries, ${elapsed}s`);
+          return true;
+        }
+
+        stats.retries++;
+      }
+
+      console.log(`Round ${retryRound + 1}: ${missingBlocks.length} blocks to send`);
+
+      // Send missing blocks in batches
+      for (let i = 0; i < missingBlocks.length; i++) {
+        const blockId = missingBlocks[i];
+        const offset = blockId * chunkSize;
+        const payload = data.slice(offset, Math.min(offset + chunkSize, data.length));
+
+        // Skip empty payloads (can occur at exact data boundaries)
+        if (payload.length === 0) {
+          continue;
+        }
+
+        // Use response for last block in batch or overall
+        const isLastInBatch = ((i + 1) % this.BATCH_SIZE === 0);
+        const isLastBlock = (i === missingBlocks.length - 1);
+        const useResponse = isLastInBatch || isLastBlock;
+
+        await this.sendBlockFast(blockId, totalBlocks, payload, useResponse);
+        stats.sentBlocks++;
+
+        if (onProgress) {
+          onProgress(i + 1, missingBlocks.length);
+        }
+      }
+
+      // Wait for MCU to process, then check status
+      await new Promise(r => setTimeout(r, this.BATCH_DELAY_MS));
+
+      // Check if all blocks received after first round
+      if (retryRound === 0) {
+        let status;
+        try {
+          status = await this.queryStatus();
+          const stillMissing = this.getMissingBlocks(status, totalBlocks);
+          if (stillMissing.length === 0) {
+            const elapsed = ((Date.now() - stats.startTime) / 1000).toFixed(1);
+            console.log(`Transfer complete: ${stats.totalBlocks} blocks, ${stats.sentBlocks} sent, 0 retries, ${elapsed}s`);
+            return true;
+          }
+        } catch (e) {
+          console.warn('Post-transfer status query failed:', e);
+        }
+      }
+    }
+
+    const elapsed = ((Date.now() - stats.startTime) / 1000).toFixed(1);
+    console.error(`Transfer failed: ${stats.totalBlocks} blocks, ${stats.sentBlocks} sent, ${stats.retries} retries, ${elapsed}s`);
+    throw new Error('Transfer failed after max retries');
+  },
+
+  /**
+   * Initialize the transfer module (call on connect)
+   */
+  init() {
+    this.pendingStatus = null;
+    this.statusResolver = null;
+    this.statusRequestId = 0;
+    this.firstBlockSent = false;
+  }
+};
+
+// Export for use in main.js
+if (typeof window !== 'undefined') {
+  window.BleTransfer = BleTransfer;
+}

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -17,6 +17,11 @@ const EpdCmd = {
 
   WRITE_IMG: 0x30, // v1.6
 
+  // CRC Transfer commands (v1.9+)
+  WRITE_BLOCK: 0x31,
+  QUERY_STATUS: 0x32,
+  RESET_TRANSFER: 0x33,
+
   SET_CONFIG: 0x90,
   SYS_RESET: 0x91,
   SYS_SLEEP: 0x92,
@@ -124,6 +129,25 @@ async function writeImage(data, step = 'bw') {
   }
 }
 
+// New CRC-verified image transfer with resume capability
+async function writeImageCRC(data, step = 'bw') {
+  const stepName = step === 'bw' ? '黑白' : '颜色';
+
+  try {
+    await BleTransfer.sendImageWithResume(data, step, (sent, total) => {
+      let currentTime = (new Date().getTime() - startTime) / 1000.0;
+      setStatus(`${stepName}块(CRC): ${sent}/${total}, 总用时: ${currentTime.toFixed(1)}s`);
+    });
+    return true;
+  } catch (e) {
+    console.error('CRC transfer failed:', e);
+    addLog(`CRC传输失败: ${e.message}，回退到普通传输`);
+    // Fallback to legacy transfer
+    await writeImage(data, step);
+    return true;
+  }
+}
+
 async function setDriver() {
   await write(EpdCmd.SET_PINS, document.getElementById("epdpins").value);
   await write(EpdCmd.INIT, document.getElementById("epddriver").value);
@@ -219,24 +243,32 @@ async function sendimg() {
 
   await write(EpdCmd.INIT);
 
+  // Use CRC transfer for firmware version >= 0x19
+  const useCRC = (appVersion >= 0x19) && (typeof BleTransfer !== 'undefined');
+  const transferFn = useCRC ? writeImageCRC : writeImage;
+
+  if (useCRC) {
+    addLog("使用CRC校验传输模式");
+  }
+
   if (ditherMode === 'fourColor') {
-    await writeImage(processedData, 'color');
+    await transferFn(processedData, 'color');
   } else if (ditherMode === 'threeColor') {
     const halfLength = Math.floor(processedData.length / 2);
     const blackWhiteData = processedData.slice(0, halfLength);
     const redWhiteData = processedData.slice(halfLength);
     if (epdDriverSelect.value === '08' || epdDriverSelect.value === '09') {
-      await writeImage(convertUC8159(blackWhiteData, redWhiteData), 'bw');
+      await transferFn(convertUC8159(blackWhiteData, redWhiteData), 'bw');
     } else {
-      await writeImage(blackWhiteData, 'bw');
-      await writeImage(redWhiteData, 'red');
+      await transferFn(blackWhiteData, 'bw');
+      await transferFn(redWhiteData, 'red');
     }
   } else if (ditherMode === 'blackWhiteColor') {
     if (epdDriverSelect.value === '08' || epdDriverSelect.value === '09') {
       const emptyData = new Uint8Array(processedData.length).fill(0xFF);
-      await writeImage(convertUC8159(processedData, emptyData), 'bw');
+      await transferFn(convertUC8159(processedData, emptyData), 'bw');
     } else {
-      await writeImage(processedData, 'bw');
+      await transferFn(processedData, 'bw');
     }
   } else {
     addLog("当前固件不支持此颜色模式。");
@@ -358,6 +390,15 @@ async function reConnect() {
 
 function handleNotify(value, idx) {
   const data = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+
+  // Route CRC transfer responses to BleTransfer module
+  if (data.length >= 1 && (data[0] === 0xA0 || data[0] === 0xA1)) {
+    if (typeof BleTransfer !== 'undefined') {
+      BleTransfer.handleNotification(value);
+    }
+    return;
+  }
+
   if (idx == 0) {
     addLog(`收到配置：${bytes2hex(data)}`);
     const epdpins = document.getElementById("epdpins");


### PR DESCRIPTION
BLE图像传输实增加ack确认
新增命令
| WRITE_BLOCK | 0x31 | APP→MCU | 带CRC的数据块写入 |
| QUERY_STATUS | 0x32 | APP→MCU | 查询传输状态 |
| RESET_TRANSFER | 0x33 | APP→MCU | 重置传输上下文 |

响应类型
| BLOCK_ACK | 0xA0 | MCU→APP | 块ACK/NACK响应 |
| STATUS | 0xA1 | MCU→APP | 传输状态响应 |

具体数据格式见：docs\BLE_CRC_Transfer_Design.md

4.2寸前后对比：前：35.879s               后：11.484s
7.5寸：前：121.542s                     后：59.320s